### PR TITLE
patch to enable use of custom field for app id

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,14 @@ require( ["js/qlik"], function ( qlik ) {
     qlik.setOnError( function ( error ) {
         console.log( error.message );
     } );
-    var app = qlik.openApp(config.id, config);
+
+    // use appid from custom field if available, fall back to the id from options page
+    if (config.qsapp) {
+	var app = qlik.openApp(config.qsapp, config);
+    } else {
+	var app = qlik.openApp(config.id, config);
+    }
+	
     if (config.id2) {
         var app2 = qlik.openApp(config.id2, config);
     }

--- a/qlik-sense.php
+++ b/qlik-sense.php
@@ -40,6 +40,7 @@
 			'qs_prefix'		=> esc_attr( get_option('qs_prefix') ),
 			'qs_id'			=> esc_attr( get_option('qs_id') ),
 			'qs_id2'		=> esc_attr( get_option('qs_id2') ),
+			'qs_appid'		=> esc_attr( get_post_meta(get_the_ID(), 'appid', true) )						
 		);
 		wp_localize_script( 'qlik-sense-js', 'vars', $translation_array );
 


### PR DESCRIPTION
This patch enables the use of a custom field called appid to store an app id. The custom field value can be set per post. If the custom field contains a value then the id of that app is used, otherwise the id value from options is used.